### PR TITLE
External Metrics Server unit tests increase the range of available ports

### DIFF
--- a/agent/src/external_metrics.rs
+++ b/agent/src/external_metrics.rs
@@ -250,7 +250,7 @@ mod tests {
         let (sender, receiver, _) =
             queue::bounded_with_debug(1000, "test_external_metrics", &queue_debugger);
 
-        let port = 44444 + random::<u16>() % 1000;
+        let port = 44444 + random::<u16>() % 10000;
         let mut rt_conf = ModuleConfig::default();
         rt_conf.metric_server.enabled = true;
         rt_conf.metric_server.port = port;


### PR DESCRIPTION
**Phenomenon and reproduction steps**

   external metrics server unit tests listening port cannot be connected

**Root cause and solution**

   increase the range of available ports

**Impactions**

   none

**Test method**

   pass all unit test

**Affected branch(es)**

 * main

**Checklist**

  - [ ] Dependencies update required
  - [ ] Common bug (similar problem in other repo)