### PR TITLE
alter Test Port Range to 20000-30000

### DIFF
--- a/agent/src/external_metrics.rs
+++ b/agent/src/external_metrics.rs
@@ -250,7 +250,7 @@ mod tests {
         let (sender, receiver, _) =
             queue::bounded_with_debug(1000, "test_external_metrics", &queue_debugger);
 
-        let port = 44444 + random::<u16>() % 10000;
+        let port = 20000 + random::<u16>() % 10000;
         let mut rt_conf = ModuleConfig::default();
         rt_conf.metric_server.enabled = true;
         rt_conf.metric_server.port = port;


### PR DESCRIPTION
**Phenomenon and reproduction steps**

CI failed 

**Root cause and solution**

Most applications use more than 30000 ports, but 20000-30000 ports are rarely used, so the port range is changed to 20000-30000


**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)