### PR TITLE
Fix agent controller ips domain name resolve

### DIFF
--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -51,9 +51,14 @@ impl Config {
             // parsing empty string leads to EOF error
             Ok(Self::default())
         } else {
-            serde_yaml::from_str(contents)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))
-                .into()
+            let mut cfg: Self = serde_yaml::from_str(contents)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+            cfg.controller_ips = cfg
+                .controller_ips
+                .drain(..)
+                .filter_map(|addr| resolve_domain(&addr))
+                .collect();
+            Ok(cfg)
         }
     }
 }


### PR DESCRIPTION
**Phenomenon and reproduction steps**

Using domain name in controller ips leads to panic

**Root cause and solution**

Domain resolve code not called

**Impactions**

Problem fixed

**Test method**

Use domain name in controller ips

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)