### PR TITLE
fix dispatcher-max-memory-too-large

### DIFF
--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -529,10 +529,8 @@ impl TryFrom<(Config, RuntimeConfig)> for ModuleConfig {
                 analyzer_ip: dest_ip,
                 proxy_controller_ip: proxy_controller_ip,
                 capture_bpf: conf.capture_bpf.to_string(),
-                max_memory: (conf.max_memory as u64) << 24,
-                af_packet_blocks: conf
-                    .yaml_config
-                    .get_af_packet_blocks((conf.max_memory as u64) << 24),
+                max_memory: conf.max_memory,
+                af_packet_blocks: conf.yaml_config.get_af_packet_blocks(conf.max_memory),
                 af_packet_version: conf.capture_socket_type.into(),
                 tap_mode: conf.yaml_config.tap_mode,
                 region_id: conf.region_id,


### PR DESCRIPTION
**Phenomenon and reproduction steps**

The max_memory field value of dispatcher config is too large and inconsistent with the max_memory issued by the controller

**Root cause and solution**

The max_memory of dispatcher config is shifted left by 24 bits, so need
delete it

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)