### PR TITLE
fix bug:use uniq with other functions panic

### DIFF
--- a/server/querier/engine/clickhouse/function.go
+++ b/server/querier/engine/clickhouse/function.go
@@ -202,7 +202,7 @@ func (f *AggFunction) FormatInnerTag(m *view.Model) (innerAlias string) {
 		m.AddTag(&innerFunction)
 		return innerAlias
 	case metrics.METRICS_TYPE_TAG:
-		innerAlias := fmt.Sprintf("_%s", f.Alias)
+		innerAlias := fmt.Sprintf("_%s", strings.Trim(f.Alias, "`"))
 		innerFunction := view.DefaultFunction{
 			Name:      view.FUNCTION_GROUP_ARRAY,
 			Fields:    []view.Node{&view.Field{Value: f.Metrics.DBField}},


### PR DESCRIPTION
**Phenomenon and reproduction steps**

**Root cause and solution**

inner alias of uniq need to trim "`"

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)