### PR TITLE
optimize k8s nodeIp and k8s-cluster-id config

### DIFF
--- a/agent/src/utils/environment.rs
+++ b/agent/src/utils/environment.rs
@@ -16,7 +16,7 @@ use super::process::{get_memory_rss, get_process_num_by_name};
 pub type Checker = Box<dyn Fn() -> Result<()>>;
 
 // K8S environment node ip environment variable
-const K8S_NODE_IP_FOR_METAFLOW: &str = "K8S_NODE_IP_FOR_METAFLOW";
+pub const K8S_NODE_IP_FOR_METAFLOW: &str = "K8S_NODE_IP_FOR_METAFLOW";
 
 pub fn check(f: Checker) {
     let mut logged = false;

--- a/agent/src/utils/net/error.rs
+++ b/agent/src/utils/net/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
     NoRouteToHost(String),
     #[error("Windows related error:{0}")]
     Windows(String),
+    #[error("{0}")]
+    LinkIdxNotFoundByIP(String),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/agent/src/utils/net/mod.rs
+++ b/agent/src/utils/net/mod.rs
@@ -219,6 +219,40 @@ pub fn is_unicast_link_local(ip: &Ipv6Addr) -> bool {
     ip.segments()[0] & 0xffc0 == 0xfe80
 }
 
+pub fn get_mac_by_ip(ip: IpAddr) -> Result<MacAddr> {
+    let links = link_list()?;
+    let addrs = addr_list()?;
+    let if_idx = addrs
+        .iter()
+        .find_map(|a| {
+            if a.ip_addr == ip {
+                Some(a.if_index)
+            } else {
+                None
+            }
+        })
+        .ok_or(Error::LinkIdxNotFoundByIP(format!(
+            "can't find interface index by ip {}",
+            ip
+        )))?;
+
+    let mac = links
+        .iter()
+        .find_map(|l| {
+            if l.if_index == if_idx {
+                Some(l.mac_addr)
+            } else {
+                None
+            }
+        })
+        .ok_or(Error::LinkIdxNotFoundByIP(format!(
+            "can't find mac address by ip {}",
+            ip
+        )))?;
+
+    Ok(mac)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
**Phenomenon and reproduction steps**

**Root cause and solution**

1. Get the Mac address from IP encapsulated into a function
2. Enable registration without configuring k8s-cluster-id

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)