### PR TITLE
Optimize to get k8s_cluster_id

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -141,6 +141,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +427,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5999502d32b9c48d492abe66392408144895020ec4709e549e840799f3bb74c0"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +523,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -745,6 +774,16 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1245,6 +1284,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "md-5"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1340,7 @@ dependencies = [
  "libc",
  "log 0.4.14",
  "lru",
+ "md-5",
  "neli",
  "nix",
  "num_enum",
@@ -2722,6 +2771,12 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "uluru"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -35,6 +35,7 @@ kube = { version = "0.64", features = ["derive", "runtime"] }
 libc = "0.2.103"
 log = "0.4"
 lru = "0.7.5"
+md-5 = "0.10.1"
 neli = "0.5.3"
 nix = "0.23"
 num_enum = "0.5.6"

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -1363,7 +1363,7 @@ impl ConfigHandler {
                 callbacks.push(metric_server_port_callback);
             }
             info!(
-                "external metric server config change from {:#?} to {:#?}",
+                "integration collector config change from {:#?} to {:#?}",
                 candidate_config.metric_server, new_config.metric_server
             );
             candidate_config.metric_server = new_config.metric_server;

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -146,7 +146,7 @@ impl Trident {
 
     fn run(
         state: TridentState,
-        config: Config,
+        mut config: Config,
         revision: &'static str,
         logger_handle: LoggerHandle,
         remote_log_config: RemoteLogConfig,
@@ -180,6 +180,12 @@ impl Trident {
             config.controller_ips.clone(),
             exception_handler.clone(),
         ));
+
+        if config.kubernetes_cluster_id.is_empty() {
+            if let Some(id) = Config::get_k8s_cluster_id(&session) {
+                config.kubernetes_cluster_id = id;
+            }
+        }
 
         let default_runtime_config = RuntimeConfig::default();
         // 目前仅支持local-mod + ebpf-collector，ebpf-collector不适用fast, 所以队列数为1


### PR DESCRIPTION
**Phenomenon and reproduction steps**

**Root cause and solution**

Call GetKubernetesClusterID RPC to get the cluster-id, if the RPC call fails, call it again
after 1 minute of sleep until it succeeds

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)