### PR TITLE
eBPF:Set a name for each eBPF threads

### DIFF
--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -2,6 +2,7 @@
 #include <arpa/inet.h>
 #include "libbpf/include/linux/err.h"
 #include <sched.h>
+#include <sys/prctl.h>
 #include "symbol.h"
 #include "tracer.h"
 #include "probe.h"
@@ -601,8 +602,10 @@ static int check_kern_adapt_and_state_update(void)
 	return 0;
 }
 
+// Manage process start or exit events.
 static void process_events_handle_main(__unused void *arg)
 {
+	prctl(PR_SET_NAME,"proc-events");
 	go_process_events_handle();
 }
 

--- a/agent/src/ebpf/user/tracer.c
+++ b/agent/src/ebpf/user/tracer.c
@@ -3,6 +3,7 @@
 #include "libbpf/include/linux/err.h"
 #include <sched.h>
 #include <sys/utsname.h>
+#include <sys/prctl.h>
 #include "probe.h"
 #include "table.h"
 #include "common.h"
@@ -699,6 +700,7 @@ __always_inline uint64_t clib_cpu_time_now(void)
 
 static void poller(void *t)
 {
+	prctl(PR_SET_NAME,"perf-reader");	
 	struct bpf_tracer *tracer = (struct bpf_tracer *)t;
 	for (;;) {
 #ifndef PERFORMANCE_TEST
@@ -765,8 +767,10 @@ int register_extra_waiting_op(const char *name, extra_waiting_fun_t f, int type)
 	return ETR_OK;
 }
 
+// Receive command line management tool requests.
 static void ctrl_main(__unused void *arg)
 {
+	prctl(PR_SET_NAME,"ctrl-main");
 	while (all_probes_ready == 0)
 		usleep(LOOP_DELAY_US);
 
@@ -895,6 +899,7 @@ static int boot_time_update(void)
 
 static void period_process_main(__unused void *arg)
 {
+	prctl(PR_SET_NAME,"period-process");
 	// 确保所有tracer都运行了，之后触发kick内核操作
 	while (all_probes_ready == 0)
 		usleep(LOOP_DELAY_US);
@@ -917,6 +922,7 @@ static void period_process_main(__unused void *arg)
  */
 static void process_datas(void *queue)
 {
+	prctl(PR_SET_NAME,"queue-worker");
 	int nr;
 	struct queue *q = (struct queue *)queue;
 	struct ring *r = q->r;


### PR DESCRIPTION
**Phenomenon and reproduction steps**

**Root cause and solution**

Like:

PID USER      PR  NI    VIRT    RES    SHR S %CPU %MEM     TIME+ COMMAND
 1573 root      20   0  212280  12752   3448 S  0.0  0.0   0:00.00 ctrl-main
 1574 root      20   0  212280  12752   3448 S  0.0  0.0   0:00.02 period-process
 1579 root      20   0  212280  12752   3448 S  0.0  0.0   0:00.00 queue-worker
 1580 root      20   0  212280  12752   3448 S  0.0  0.0   0:00.00 perf-reader
 1581 root      20   0  212280  12752   3448 S  0.0  0.0   0:00.00 proc-events

Describe:

- ctrl-main
  Receive command tool requests and respond accordingly.
- period-process
  Periodic event processing, e.g.: Kick kernel, send datas to user. Periodically check the eBPF map capacity.
- queue-worker
  Retrieves data from the queue and calls back the application interface for processing.
- perf-reader
  From perf buffer-ring read datas and dispatch to queues.
- proc-events
  Process exec/exit events.

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)