### PR TITLE
[CONTROLLER-TAGRECORDER] fix call web service error

### DIFF
--- a/server/controller/config/config.go
+++ b/server/controller/config/config.go
@@ -33,10 +33,19 @@ type Specification struct {
 	DataSourceRetentionTimeMax int `default:"1000" yaml:"data_source_retention_time_max"`
 }
 
+type DFWebService struct {
+	Enabled bool   `default:"true" yaml:"enabled"`
+	Host    string `default:"df-web" yaml:"host"`
+	Port    int    `default:"20106" yaml:"port"`
+	Timeout int    `default:"30" yaml:"timeout"`
+}
+
 type ControllerConfig struct {
 	LogFile              string `default:"/var/log/controller.log" yaml:"log-file"`
 	LogLevel             string `default:"info" yaml:"log-level"`
 	MasterControllerName string `default:"" yaml:"master-controller-name"`
+
+	DFWebService DFWebService `yaml:"df-web-service"`
 
 	MySqlCfg      mysql.MySqlConfig           `yaml:"mysql"`
 	RedisCfg      redis.RedisConfig           `yaml:"redis"`

--- a/server/controller/tagrecorder/constraint.go
+++ b/server/controller/tagrecorder/constraint.go
@@ -7,10 +7,14 @@ import (
 
 // 资源的MySQL orm对象
 type MySQLChModel interface {
-	mysql.ChPodGroupPort | mysql.ChPodPort | mysql.ChVTapPort | mysql.ChAZ | mysql.ChIPResource | mysql.ChK8sLabel | mysql.ChLBListener | mysql.ChPodNodePort | mysql.ChIPPort | mysql.ChDevicePort | mysql.ChRegion | mysql.ChVPC | mysql.ChDevice | mysql.ChIPRelation | mysql.ChPodGroup | mysql.ChNetwork | mysql.ChPod | mysql.ChPodCluster | mysql.ChPodNode | mysql.ChPodNamespace | mysql.ChTapType | mysql.ChVTap
+	mysql.ChPodGroupPort | mysql.ChPodPort | mysql.ChVTapPort | mysql.ChAZ | mysql.ChIPResource | mysql.ChK8sLabel |
+		mysql.ChLBListener | mysql.ChPodNodePort | mysql.ChIPPort | mysql.ChDevicePort | mysql.ChRegion | mysql.ChVPC |
+		mysql.ChDevice | mysql.ChIPRelation | mysql.ChPodGroup | mysql.ChNetwork | mysql.ChPod | mysql.ChPodCluster |
+		mysql.ChPodNode | mysql.ChPodNamespace | mysql.ChTapType | mysql.ChVTap
 }
 
 // ch资源的组合key
 type ChModelKey interface {
-	VtapPortKey | IPResourceKey | K8sLabelKey | PortIDKey | PortIPKey | PortDeviceKey | IDKey | DeviceKey | IPRelationKey | TapTypeKey
+	VtapPortKey | IPResourceKey | K8sLabelKey | PortIDKey | PortIPKey | PortDeviceKey | IDKey | DeviceKey |
+		IPRelationKey | TapTypeKey
 }

--- a/server/controller/tagrecorder/icon.go
+++ b/server/controller/tagrecorder/icon.go
@@ -2,6 +2,7 @@ package tagrecorder
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/metaflowys/metaflow/server/controller/common"
 	"github.com/metaflowys/metaflow/server/controller/db/mysql"
@@ -20,8 +21,11 @@ type IconKey struct {
 func (c *TagRecorder) UpdateIconInfo() (map[string]int, map[IconKey]int, error) {
 	domainToIconID := make(map[string]int)
 	resourceToIconID := make(map[IconKey]int)
+	if !c.cfg.DFWebService.Enabled {
+		return domainToIconID, resourceToIconID, nil
+	}
 	body := make(map[string]interface{})
-	response, err := common.CURLPerform("GET", "http://df-web:20825/v1/icons", body)
+	response, err := common.CURLPerform("GET", fmt.Sprintf("http://%s:%d/v1/icons", c.cfg.DFWebService.Host, c.cfg.DFWebService.Port), body)
 	if err != nil {
 		log.Error(err)
 		return domainToIconID, resourceToIconID, err

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -6,6 +6,13 @@ controller:
   # controller http listenport
   listen-port: 20417
 
+  # deepflow web service config
+  df-web-service:
+    enabled: true
+    host: df-web
+    port: 20825
+    timeout: 30
+
   # mysql相关配置
   mysql:
     database: deepflow


### PR DESCRIPTION
**Phenomenon and reproduction steps**

**Root cause and solution**

- web service is not supported in metaflow, tagrecorder alway call it failed
- check whether web service is supported by config, call it to set icon info if it is, else not

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)