### PR TITLE
[querier]fix-bug:get datasource interval error

### DIFF
--- a/server/querier/engine/clickhouse/common/utils.go
+++ b/server/querier/engine/clickhouse/common/utils.go
@@ -109,6 +109,8 @@ func GetDatasourceInterval(db string, table string, name string) (int, error) {
 		} else if table == "vtap_app_port" || table == "vtap_app_edge_port" {
 			tsdbType = "app"
 		}
+	default:
+		return 1, nil
 	}
 	client := &http.Client{}
 	url := fmt.Sprintf("http://localhost:20417/v1/data-sources/?name=%s&type=%s", name, tsdbType)


### PR DESCRIPTION
**Phenomenon and reproduction steps**

**Root cause and solution**

when db not in ["flow_log", "flow_metrics"],datasource_interval=1

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)