### PR TITLE
[cli] remove build darwin-arm64

### DIFF
--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -38,6 +38,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.6.1'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build cli
         run: |
@@ -80,7 +81,7 @@ jobs:
           ossutil cp -rf cli/bin/metaflow-ctl.linux-amd64 oss://metaflow/bin/ctl/${{ env.IMAGE_TAG_PREFIX }}/linux/amd64/metaflow-ctl
           ossutil cp -rf cli/bin/metaflow-ctl.linux-arm64 oss://metaflow/bin/ctl/${{ env.IMAGE_TAG_PREFIX }}/linux/arm64/metaflow-ctl
           ossutil cp -rf cli/bin/metaflow-ctl.darwin-amd64 oss://metaflow/bin/ctl/${{ env.IMAGE_TAG_PREFIX }}/osx/amd64/metaflow-ctl
-          ossutil cp -rf cli/bin/metaflow-ctl.darwin-arm64 oss://metaflow/bin/ctl/${{ env.IMAGE_TAG_PREFIX }}/osx/arm64/metaflow-ctl
+          # ossutil cp -rf cli/bin/metaflow-ctl.darwin-arm64 oss://metaflow/bin/ctl/${{ env.IMAGE_TAG_PREFIX }}/osx/arm64/metaflow-ctl
 
       # - name: Prepare for upload package
       #   shell: bash

--- a/.github/workflows/cli-verify.yml
+++ b/.github/workflows/cli-verify.yml
@@ -25,7 +25,8 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.6.1'
-      
+          repo-token: ${{ secrets.GITHUB_TOKEN }}      
+
       - name: verify cli
         run: |
           sudo apt-get install tmpl


### PR DESCRIPTION
**Phenomenon and reproduction steps**

**Root cause and solution**

- netlink package is missing in darwin-arm64

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)