### PR TITLE
[AGENT] fix get k8s_cluster_id restart to connect metaflow-server

### DIFF
--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -122,6 +122,7 @@ impl Config {
                 let client = match session.get_client() {
                     Some(c) => c,
                     None => {
+                        session.set_request_failed(true);
                         warn!("rpc client not connected");
                         tokio::time::sleep(MINUTE).await;
                         continue;


### PR DESCRIPTION
**Phenomenon and reproduction steps**

When the first connection to metaflow-server fails, you need to restart the agent to connect

**Root cause and solution**

cause: No request failure status set, resulting in no redial to metaflow-server

solution: set request failure status

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)