### PR TITLE
eBPF: Modify the Linux kernel adaptive method

### DIFF
--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -165,6 +165,7 @@ enum {
 	ETR_NOTGOELF = -5,      /* not go elf */
 	ETR_NOPROT = -7,	/* no protocol */
 	ETR_NOSYMBOL = -8,	/* no uprobe symbols */
+	ETR_UPDATE_MAP_FAILD = -9, /* update map faild */
 	ETR_IDLE = -12,		/* nothing to do */
 	ETR_BUSY = -13,		/* resource busy */
 	ETR_NOTSUPP = -14,	/* not support */
@@ -201,6 +202,7 @@ static struct trace_err_tab err_tab[] = {
 	{ETR_NOTGOELF, "not go elf"},
 	{ETR_NOPROT, "no protocol"},
 	{ETR_NOSYMBOL, "no uprobe symbols"},
+	{ETR_UPDATE_MAP_FAILD, "update map faild"},
 	{ETR_IDLE, "nothing to do"},
 	{ETR_BUSY, "resource busy"},
 	{ETR_NOTSUPP, "not support"},


### PR DESCRIPTION
**Phenomenon and reproduction steps**

**Root cause and solution**

The original method is that the final adaptation is successful when all cpus corresponding to offset values are successfully adapted, now if only one CPU offset is successfully adapted, the entire adaptation is successful.

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)