### PR TITLE
[eBPF]: Solve the problem of tracking breakage caused by non-tracking…

### DIFF
--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -104,7 +104,7 @@ struct trace_info_t {
 	__u32 update_time; // 从系统开机开始到创建/更新时的间隔时间单位是秒
 	__u32 peer_fd;	   // 用于socket之间的关联
 	__u64 thread_trace_id; // 线程追踪ID
-	__u64 conn_key; // 链接记录哈希表(socket_info_map)中的key值。
+	__u64 socket_id; // Records the socket associated when tracing was created (记录创建追踪时关联的socket)
 };
 
 // struct member_offsets -> data[]  arrays index.


### PR DESCRIPTION
… between the same sockets

**Phenomenon and reproduction steps**

**Root cause and solution**

Since it is determined whether it is the same socket when tracking, we use 'conn_key' (value: {tgid + fd}) will be problems. At function delete_socket_info() will delete fd, but it is still used when tracking. The process may use a previously closed file handle number when creating a new socket, this change is not updated on tracing, mistakenly identified as the same socket breaks tracking logic.

solution:

Use 'socket_id' instead of 'conn_key', 'socket_id' is an perCPU incrementing number that won't reproduce duplicates.

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)