### PR TITLE
[AGENT] fix integration collector lost port warning log

### DIFF
--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -1399,15 +1399,10 @@ impl ConfigHandler {
         // lose monitoring after a period of time. So first detect whether the issued port is listening,
         // If not listening, restart the collector and listen again. After finding the root cause, remove the following code
         let port = candidate_config.metric_server.port;
-        if !check_listen_port_alive(port) {
-            fn metric_server_restart_callback(
-                handler: &ConfigHandler,
-                components: &mut Components,
-            ) {
-                if handler.candidate_config.metric_server.enabled {
-                    components.external_metrics_server.stop();
-                    components.external_metrics_server.start();
-                }
+        if candidate_config.metric_server.enabled && !check_listen_port_alive(port) {
+            fn metric_server_restart_callback(_: &ConfigHandler, components: &mut Components) {
+                components.external_metrics_server.stop();
+                components.external_metrics_server.start();
             }
             callbacks.push(metric_server_restart_callback);
             warn!(


### PR DESCRIPTION
**Phenomenon and reproduction steps**

If it is not expected to listen, the lost listening port log will also be printed.

**Root cause and solution**

Only when the collector is enabled and the listening port is lost, the log of the lost listening port is printed.

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)