### PR TITLE
[eBPF] Add eBPF bytecodes to the executable file metaflow-agent

### DIFF
--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -144,8 +144,7 @@ jobs:
 
       - name: build binary package  
         run: |
-          mkdir -p agent/bin-package/depends
-          cp -raf agent/output/src/ebpf/data/* agent/bin-package/depends
+          mkdir -p agent/bin-package
           cp -raf agent/output/target/release/metaflow-agent agent/bin-package/
           cd agent/bin-package/
           tar -czvf metaflow-agent.tar.gz *

--- a/agent/docker/dockerfile
+++ b/agent/docker/dockerfile
@@ -14,8 +14,7 @@ RUN --mount=target=/tmp-mount \
     echo "metaflow:x:1000:1000::/home/metaflow:/bin/bash" >> /etc/passwd; \
     echo "root:root" | chpasswd; \
     chmod 000 /etc/passwd; \
-    mkdir -p /lib64 /usr/share/metaflow-agent && \
-    cp -raf /tmp-mount/output/src/ebpf/data/* /usr/share/metaflow-agent && \
+    mkdir -p /lib64 && \
     cp -raf /tmp-mount/output/target/release/metaflow-agent /bin/  && \
     cp -raf /tmp-mount/output/target/release/metaflow-agent-ctl /bin/  && \
     cp -raf /tmp-mount/output/src/ebpf/metaflow-ebpfctl /bin/  && \

--- a/agent/metaflow-agent.spec
+++ b/agent/metaflow-agent.spec
@@ -27,16 +27,11 @@ mkdir -p $RPM_BUILD_ROOT/lib/systemd/system/
 cp %pwd/metaflow-agent.service $RPM_BUILD_ROOT/lib/systemd/system/
 mkdir -p $RPM_BUILD_ROOT/etc/
 cp %pwd/config/metaflow-agent.yaml $RPM_BUILD_ROOT/etc/
-mkdir -p $RPM_BUILD_ROOT/usr/share/metaflow-agent/
-cp -r %pwd/output/src/ebpf/data/* $RPM_BUILD_ROOT/usr/share/metaflow-agent/
 
 %files
 /usr/sbin/metaflow-agent
 /lib/systemd/system/metaflow-agent.service
 %config(noreplace) /etc/metaflow-agent.yaml
-/usr/share/metaflow-agent/linux-5.2/socket_trace.elf
-/usr/share/metaflow-agent/linux-common/socket_trace.elf
-/usr/share/metaflow-agent/linux-core/socket_trace.elf
 
 %preun
 # sles: suse linux

--- a/agent/src/ebpf/Makefile
+++ b/agent/src/ebpf/Makefile
@@ -12,9 +12,9 @@ STATIC_OBJDIR := $(OBJDIR)/staticobjs
 
 define compile_socket_trace_elf
 	@echo "  COMPILE ELF kernel version $(1)"
-	@mkdir -p data/linux-$(strip $1)
 	@cd kernel && make clean --no-print-directory && make socket_trace.elf $(2) --no-print-directory && cd ../
-	@cp kernel/socket_trace.elf data/linux-$(strip $1)/
+	@echo "  Generate file user/socket_trace_bpf_$(strip $1).c"
+	@./tools/ebpftobuffer kernel/socket_trace.elf user/socket_trace_bpf_$(strip $1).c socket_trace_$(strip $1)_ebpf_data
 endef
 
 CURRDIR := $(PWD)
@@ -70,8 +70,10 @@ $(ELFFILES):
                 echo "  check llvm-clang fail. expect Clang/LLVM 10+" && exit 1; \
         fi
 	@rm -rf data
+	$(call msg,Tools,,tools/ebpftobuffer)
+	@gcc tools/ebpftobuffer.c -o tools/ebpftobuffer
 	$(call compile_socket_trace_elf, common)
-	$(call compile_socket_trace_elf, 5.2, LINUX_VER_5_2=1)
+	$(call compile_socket_trace_elf, 5_2, LINUX_VER_5_2=1)
 	$(call compile_socket_trace_elf, core, CORE=1)
 	@touch $(ELFFILES)
 
@@ -92,10 +94,6 @@ $(LIBBPF_DIR):
 	@cd ../../../ && git submodule update --init --recursive && cd $(CURRDIR)
 	
 build: $(LIBBPF_DIR) $(ELFFILES) $(LIBTRACE)
-install:
-	rm -rf /usr/share/metaflow-agent
-	mkdir -p /usr/share/metaflow-agent
-	cp data/* /usr/share/metaflow-agent/ -raf
 
 tools: $(LIBBPF_DIR) $(LIBTRACE)
 	$(call msg,TOOLS,metaflow-ebpfctl)
@@ -118,5 +116,5 @@ clean:
 test: $(LIBBPF_DIR) $(ELFFILES) $(LIBTRACE)
 	$(Q)$(MAKE) -C test --no-print-directory
 
-.PHONY: all build clean install tools test
+.PHONY: all build clean tools test
 

--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -104,7 +104,7 @@ struct trace_info_t {
 	__u32 update_time; // 从系统开机开始到创建/更新时的间隔时间单位是秒
 	__u32 peer_fd;	   // 用于socket之间的关联
 	__u64 thread_trace_id; // 线程追踪ID
-	__u64 conn_key; // 链接记录哈希表(socket_info_map)中的key值。
+	__u64 socket_id; // Records the socket associated when tracing was created (记录创建追踪时关联的socket)
 };
 
 // struct member_offsets -> data[]  arrays index.

--- a/agent/src/ebpf/kernel/socket_trace.c
+++ b/agent/src/ebpf/kernel/socket_trace.c
@@ -264,13 +264,14 @@ static __inline bool get_socket_info(struct __socket_data *v,
 				     struct conn_info_t* conn_info)
 {
 	/*
-	 * 下面两行在linux5.2版本会出现指令超限问题
+	 * 下面if判断在linux5.2版本会出现指令超限问题
 	 * 而去掉下面两个行linux5.13，Linux5.3版本（也可能有其他版本）的内核则会出现指令超限问题。
 	 * 目前的解决方案: 保留判断, 为linux5.2内核单独编译。
 	 */
-	
+#ifndef LINUX_VER_5_2 	
 	if (v == NULL || sk == NULL)
 		return false;
+#endif
 
 #ifdef BPF_USE_CORE
 	struct sock *__sk = sk;

--- a/agent/src/ebpf/tools/ebpftobuffer.c
+++ b/agent/src/ebpf/tools/ebpftobuffer.c
@@ -1,0 +1,101 @@
+/*
+ * file: tools/ebpftobuffer.c
+ *
+ * This tool is used to convert eBPF bytecode into a buffer in C file.
+ *
+ * Uage: ebpftobuffer <ebpf-elf-file> <target-file> <variable-name>
+ * @ebpf-elf-file : eBPF binary file path (to be converted)
+ * @target-file : target c file path
+ * @variable-name : buffer variable name
+ */
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+#include <malloc.h>
+
+static unsigned char *read_bin_file(char *name, int *len)
+{
+	FILE *file;
+	unsigned char *buffer;
+	unsigned long file_len;
+
+	//Open file
+	file = fopen(name, "rb");
+	if (!file) {
+		fprintf(stderr, "Unable to open file %s", name);
+		return NULL;
+	}
+	//Get file length
+	fseek(file, 0, SEEK_END);
+	file_len = ftell(file);
+	fseek(file, 0, SEEK_SET);
+
+	//Allocate memory
+	buffer = (char *)malloc(file_len + 1);
+	if (!buffer) {
+		fprintf(stderr, "Memory error!");
+		fclose(file);
+		return NULL;
+	}
+	//Read file contents into buffer
+	fread(buffer, file_len, 1, file);
+	fclose(file);
+	//Do what ever with buffer
+	*len = file_len;
+	return buffer;
+}
+
+int main(int argc, char *argv[])
+{
+	if (argc < 4) {
+		printf("Uage:%s <ebpf-elf-file> <target-file> <variable-name>\n",
+		       argv[0]);
+		return -1;
+	}
+	char *ebpf_elf_file = argv[1];
+	char *target_file = argv[2];
+	char *variable_name = argv[3];
+
+	int len = 0;
+	unsigned char *data =
+	    read_bin_file(ebpf_elf_file, &len);
+	if (len <= 0 || data == NULL) {
+		fprintf(stderr, "Unable to read file %s", argv[1]);
+		if (data != NULL)
+			free(data);
+		return -1;
+
+	}
+
+	char data_buf[1024];
+	remove(target_file);
+	int target_fd = open(target_file, O_RDWR | O_CREAT | O_APPEND, 0777);
+	if (target_fd == -1) {
+		fprintf(stderr, "open(%s) faild.\n", target_file);
+		return -1;
+	}
+	snprintf(data_buf, sizeof(data_buf), "static const unsigned char %s[] = \"",
+		 variable_name);
+	int data_len = strlen(data_buf);
+	if (write(target_fd, data_buf, data_len) != data_len) {
+		fprintf(stderr, "Error writing to the file.\n");
+		return -1;
+	}
+	int i;
+	for (i = 0; i < len; i++) {
+		snprintf(data_buf, sizeof(data_buf), "\\x%02x", data[i]);
+		data_len = strlen(data_buf);
+		if (write(target_fd, data_buf, data_len) != data_len) {
+			fprintf(stderr, "Error writing to the file.\n");
+			return -1;
+		}
+	}
+
+	write(target_fd, "\";\n", 3);
+	close(target_fd);
+	free(data);
+	return 0;
+}

--- a/agent/src/ebpf/user/ctrl_tracer.c
+++ b/agent/src/ebpf/user/ctrl_tracer.c
@@ -90,7 +90,7 @@ static void tracer_dump(struct bpf_tracer_param *param)
 	struct bpf_tracer_param *btp = param;
 	struct rx_queue_info *rx_q;
 	printf("%-18s %s\n", "Tracer", btp->name);	//, sizeof(btp->name), "%s", t->name);
-	printf("%-18s %s\n", "Bpf File", btp->bpf_file);
+	printf("%-18s %s\n", "Bpf buffer", btp->bpf_load_name);
 	printf("%-18s %d\n", "Workers", btp->dispatch_workers_nr);
 	printf("%-18s %d\n", "Perf-Pages-Count", btp->perf_pg_cnt);
 	printf("%-18s %" PRIu64 "\n", "Events Lost", btp->lost);

--- a/agent/src/ebpf/user/tracer.h
+++ b/agent/src/ebpf/user/tracer.h
@@ -45,7 +45,6 @@
 #define BPF_PERF_READER_PAGE_CNT  64
 
 #define NAME_LEN 64
-#define TRACER_PATH_LEN 1024
 
 #define TYPE_KPROBE     0
 #define TYPE_UPROBE     1
@@ -75,8 +74,6 @@ enum probe_type {
 
 // use for inference struct offset.
 #define OFFSET_INFER_SERVER_PORT 54583
-
-#define ELF_PATH_PREFIX  "/usr/share/metaflow-agent/"
 
 static inline unsigned int min_log2(unsigned int x)
 {
@@ -230,7 +227,10 @@ struct bpf_tracer {
 	 * tracer info
 	 */
 	char name[NAME_LEN];	// tracer name
-	char bpf_file[TRACER_PATH_LEN];	// tracer bpf binary file path.
+	char bpf_load_name[NAME_LEN];	// Tracer bpf load buffer name.
+					// Used to identify which eBPF buffer is loaded by the kernel
+	void *buffer_ptr;		// eBPF bytecodes buffer pointer
+	int buffer_sz;			// eBPF buffer size
 	struct bpf_object *pobj;	// libbpf define bpf object
 
 	/*
@@ -319,7 +319,7 @@ struct rx_queue_info {
 
 struct bpf_tracer_param {
 	char name[NAME_LEN];
-	char bpf_file[TRACER_PATH_LEN];
+	char bpf_load_name[NAME_LEN];
 	int dispatch_workers_nr;
 	unsigned int perf_pg_cnt;
 	struct rx_queue_info rx_queues[MAX_CPU_NR];
@@ -405,7 +405,9 @@ int register_extra_waiting_op(const char *name,
 			      extra_waiting_fun_t f, int type);
 void bpf_tracer_finish(void);
 struct bpf_tracer *create_bpf_tracer(const char *name,
-				     char *bpf_file,
+				     char *load_name,
+				     void *bpf_bin_buffer,
+				     int buffer_sz,
 				     struct tracer_probes_conf *tps,
 				     int workers_nr,
 				     void *handle, unsigned int perf_pages_cnt);

--- a/agent/src/ebpf_collector/ebpf_collector.rs
+++ b/agent/src/ebpf_collector/ebpf_collector.rs
@@ -881,8 +881,7 @@ impl EbpfCollector {
                 retry_count = retry_count + 1;
                 if retry_count >= RETRY_MAX {
                     error!(
-                        "The tracer_start() error. Kernel offset adapt failed. \
-                         Check for 'bpf.elf' has been updated at \"/usr/share/metaflow-agent\".\n"
+                        "The tracer_start() error. Kernel offset adapt failed.\n"
                     );
                 }
             }


### PR DESCRIPTION
    **Phenomenon and reproduction steps**

    **Root cause and solution**

    - Delete the dependency on /usr/share/metaflow-agent and directly write eBPF bytecode to the metaflow-agent executable file.

    **Impactions**

    **Test method**

    **Affected branch(es)**

    * main

    **Checklist**

    - [ ] Dependencies update required
    - [ ] Common bug (similar problem in other repo)