### PR TITLE
[Tagrecorder][Querier]clickhouse database rename

### DIFF
--- a/server/server.yaml
+++ b/server/server.yaml
@@ -145,7 +145,7 @@ querier:
 
   # clickhouse相关配置
   clickhouse:
-    database: deepflow
+    database: flow_tag
     user: default
     host: clickhouse
     port: 9000


### PR DESCRIPTION
**Phenomenon and reproduction steps**

**Root cause and solution**

 - Cliskhouse database name is changed from deepflow to flow_tag

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)