### PR TITLE
[eBPF] Fun ’resolve_bin_file()‘ optimize

### DIFF
--- a/agent/src/ebpf/user/go_tracer.h
+++ b/agent/src/ebpf/user/go_tracer.h
@@ -16,7 +16,7 @@ struct data_members {
 struct proc_offsets {
 	struct list_head list;
 	int pid;
-	const char *path;
+	char *path;
 	unsigned long long starttime;	// The time the process started after system boot.
 	struct member_offsets offs;
 	bool has_updated;		// if update eBPF map ?


### PR DESCRIPTION
**Phenomenon and reproduction steps**

**Root cause and solution**

Initializing `struct proc_offsets` multiple times leads to time-consuming and memory leaks

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)