### PR TITLE
[Querier]Clickhouse database rename

### DIFF
--- a/server/querier/engine/clickhouse/tag/description.go
+++ b/server/querier/engine/clickhouse/tag/description.go
@@ -218,7 +218,7 @@ func GetTagDescriptions(db, table, rawSql string) (map[string][]interface{}, err
 		Port:     config.Cfg.Clickhouse.Port,
 		UserName: config.Cfg.Clickhouse.User,
 		Password: config.Cfg.Clickhouse.Password,
-		DB:       "deepflow",
+		DB:       "flow_tag",
 	}
 	sql := "SELECT key FROM k8s_label_map GROUP BY key"
 	rst, err := chClient.DoQuery(sql, nil, "")


### PR DESCRIPTION
**Phenomenon and reproduction steps**

**Root cause and solution**

 - clickhosue database name is changed from deepflow into flow_tag

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)